### PR TITLE
Create data/config dirs recursively

### DIFF
--- a/recipes/configuration.rb
+++ b/recipes/configuration.rb
@@ -6,6 +6,12 @@
 
 pg_version = node["postgresql"]["version"]
 
+directory "/etc/postgresql/#{pg_version}/main/" do
+  owner  "postgres"
+  group  "postgres"
+  recursive true
+end
+
 # environment
 template "/etc/postgresql/#{pg_version}/main/environment" do
   source "environment.erb"

--- a/recipes/data_directory.rb
+++ b/recipes/data_directory.rb
@@ -9,6 +9,7 @@ directory node["postgresql"]["data_directory"] do
   owner  "postgres"
   group  "postgres"
   mode   "0700"
+  recursive true
   not_if "test -f #{node["postgresql"]["data_directory"]}/PG_VERSION"
 end
 


### PR DESCRIPTION
Install failed on Debian 6 using chef 11.4.4 as
the containing directories of the config/data
directory didn't exist and weren't set up by the
recipe. Fixed by using the `recursive true` option.
