### PR TITLE
Adding ability to configure apt distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,19 @@ You may also set the contents of `pg_hba.conf` via attributes:
 }
 ```
 
+### Change APT distribution
+
+Currently the APT distributions are sourced from [http://apt.postgresql.org/pub/repos/apt/](http://apt.postgresql.org/pub/repos/apt/).
+In some cases this source might not immediately contain a package for the distribution of your target system.
+
+The `node["postgresql"]["apt_distribution"]` attribute can be used to install PostgreSQL from a different compatible
+distribution:
+
+```json
+"postgresql": {
+  "apt_distribution": "precise"
+}
+```
 
 ## Attributes
 
@@ -176,6 +189,7 @@ You may also set the contents of `pg_hba.conf` via attributes:
 # FILE LOCATIONS (see below) attributes *must* also be overridden in
 # order to re-compute the paths with the correct version number.
 default["postgresql"]["version"]                         = "9.2"
+default["postgresql"]["apt_distribution"]                = node["lsb"]["codename"]
 
 default["postgresql"]["environment_variables"]           = {}
 default["postgresql"]["pg_ctl_options"]                  = ""

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -8,6 +8,7 @@
 #
 
 default["postgresql"]["version"]                         = "9.2"
+default["postgresql"]["apt_distribution"]                = node["lsb"]["codename"]
 
 default["postgresql"]["environment_variables"]           = {}
 default["postgresql"]["pg_ctl_options"]                  = ""

--- a/recipes/apt_repository.rb
+++ b/recipes/apt_repository.rb
@@ -7,7 +7,7 @@
 # use `apt.postgresql.org` for primary package installation support
 apt_repository "apt.postgresql.org" do
   uri "http://apt.postgresql.org/pub/repos/apt"
-  distribution "#{node["lsb"]["codename"]}-pgdg"
+  distribution "#{node["postgresql"]["apt_distribution"]}-pgdg"
   components ["main"]
   key "http://apt.postgresql.org/pub/repos/apt/ACCC4CF8.asc"
   action :add


### PR DESCRIPTION
This is useful for cases such as when a specific distribution of
the package is not yet available on apt.postgresql.org but a
compatible version is available in an older distribution repo.

By default the current system distribution is used.

Current use case: raring packages aren't available, but works well with precise
