### PR TITLE
pg_user recipe was not idempotent. Updated sql for testing the existence...

### DIFF
--- a/definitions/pg_user.rb
+++ b/definitions/pg_user.rb
@@ -20,7 +20,7 @@ define :pg_user, action: :create do
 
     sql = sql.join(" ")
 
-    exists = [%(psql -c "SELECT usename FROM pg_user WHERE usename='#{params[:name]}'")]
+    exists = [%(psql -c "SELECT rolname FROM pg_roles WHERE rolname='#{params[:name]}'")]
     exists.push "| grep #{params[:name]}"
     exists = exists.join ' '
 


### PR DESCRIPTION
pg_user recipe was not idempotent. Updated sql for testing the existence of a user to query against pg_roles instead of pg_user. A user created with NOLOGIN will not have an entry in pg_user table, thus subsequent runs would fail if a user was created with NOLOGIN
