### PR TITLE
adds basic kitchen tests for postgresql cookbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ vendor/bundle
 .DS_Store
 build/*
 tmp/
+.kitchen/
+.kitchen.local.yml

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,17 @@
+---
+driver:
+  name: vagrant
+
+provisioner:
+  name: chef_solo
+
+platforms:
+  - name: ubuntu-12.04
+
+suites:
+  - name: default
+    run_list:
+      - recipe[apt]
+      - recipe[postgresql::default]
+      - recipe[postgresql::server]
+    attributes:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,5 @@ rvm:
   - 1.9.3
   - 2.0.0
 script:
-  - bundle exec rake test
+  - bundle exec foodcritic --epic-fail any ./
+  - bundle exec kitchen test --parallel --log-level=info --destroy=always

--- a/Berksfile
+++ b/Berksfile
@@ -1,0 +1,3 @@
+site :opscode
+
+metadata

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem "rake"
+gem 'foodcritic', '~> 2.1'
+gem "chef", ">= 10.12.0"

--- a/Rakefile
+++ b/Rakefile
@@ -31,3 +31,10 @@ private
 def sandbox_path
   File.join(File.dirname(__FILE__), %w[tmp cookbooks cookbook])
 end
+
+begin
+  require 'kitchen/rake_tasks'
+  Kitchen::RakeTasks.new
+rescue LoadError
+  puts ">>>>> Kitchen gem not loaded, omitting tasks" unless ENV['CI']
+end

--- a/definitions/pg_database.rb
+++ b/definitions/pg_database.rb
@@ -10,7 +10,7 @@ define :pg_database, action: :create do
     template: nil,
     owner: nil,
   }
-  
+
   defaults.merge! params
 
   exists = ["psql"]

--- a/test/integration/default/bats/verify_install.bats
+++ b/test/integration/default/bats/verify_install.bats
@@ -1,0 +1,22 @@
+control_script="sudo /etc/init.d/postgresql"
+
+setup() {
+  $control_script stop || true
+  $control_script start
+}
+
+teardown() {
+  $control_script stop || true
+}
+
+@test "postgresql.conf file must exist" {
+  test -f /etc/postgresql/*/main/postgresql.conf
+}
+
+@test "pg_hba.conf file must exist" {
+  test -f /etc/postgresql/*/main/pg_hba.conf
+}
+
+@test "postgres must reload cleanly" {
+  $control_script reload
+}


### PR DESCRIPTION
- basic bats tests for postgresql process
- added a few tests for configuration files (postgresql.conf and pg_hba.conf)
- added minimal Berkshelf file to manage apt dependency in test kitcken

I'm happy to add more tests (or adjust as needed).  Just wanted to make sure I pull requested while everything passes.

```
-----> Setting up <default-ubuntu-1204>...
Fetching: thor-0.18.1.gem (100%)
Fetching: busser-0.6.0.gem (100%)
Successfully installed thor-0.18.1
Successfully installed busser-0.6.0
2 gems installed
-----> Setting up Busser
       Creating BUSSER_ROOT in /tmp/busser
       Creating busser binstub
       Plugin bats installed (version 0.1.0)
-----> Running postinstall for bats plugin
      create  /tmp/bats20140206-3301-1gytv60/bats
      create  /tmp/bats20140206-3301-1gytv60/bats.tar.gz
Installed Bats to /tmp/busser/vendor/bats/bin/bats
      remove  /tmp/bats20140206-3301-1gytv60
       Finished setting up <default-ubuntu-1204> (0m9.08s).
-----> Verifying <default-ubuntu-1204>...
       Suite path directory /tmp/busser/suites does not exist, skipping.
Uploading /tmp/busser/suites/bats/verify_install.bats (mode=0644)
-----> Running bats test suite
 ✓ postgresql.conf file must exist
 ✓ pg_hba.conf file must exist
 ✓ postgres must reload cleanly

3 tests, 0 failures
```

There are a few things that food critic found but I will try to tackle those in a separate pull request (see http://acrmp.github.io/foodcritic/#FC015 and http://acrmp.github.io/foodcritic/#FC022 for more information)

```
postgresql [kitchen_tests]$ bundle exec foodcritic --epic-fail any ./
FC015: Consider converting definition to a LWRP: ./definitions/pg_database.rb:1
FC015: Consider converting definition to a LWRP: ./definitions/pg_database_extensions.rb:1
FC015: Consider converting definition to a LWRP: ./definitions/pg_user.rb:1
FC022: Resource condition within loop may not behave as expected: ./definitions/pg_database_extensions.rb:1
```
