### PR TITLE
Change encoding/locales to fix error

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,9 @@ Or add users via attributes:
 # create a database
 pg_database "mydb" do
   owner "myuser"
-  encoding "utf8"
+  encoding "UTF-8"
   template "template0"
-  locale "en_US.UTF8"
+  locale "en_US.UTF-8"
 end
 
 # install extensions to database
@@ -132,8 +132,8 @@ Or add the database via attributes:
       "name": "my_db",
       "owner": "dickeyxxx",
       "template": "template0",
-      "encoding": "utf8",
-      "locale": "en_US.UTF8",
+      "encoding": "UTF-8",
+      "locale": "en_US.UTF-8",
       "extensions": "hstore"
     }
   ]


### PR DESCRIPTION
I'm not _exactly_ sure why, but the utf8 settings for encoding and locale caused an error when I tried to use them (using postgresql 9.3). Changing those settings to `UTF-8` fixed the issue and made the correct database with encodings.
