### PR TITLE
apt_key location has changed

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,7 +17,7 @@ default["postgresql"]["apt_distribution"] = node["lsb"]["codename"]
 default["postgresql"]["apt_repository"]   = "apt.postgresql.org"
 default["postgresql"]["apt_uri"]          = "http://apt.postgresql.org/pub/repos/apt"
 default["postgresql"]["apt_components"]   = ["main"]
-default["postgresql"]["apt_key"]          = "http://apt.postgresql.org/pub/repos/apt/ACCC4CF8.asc"
+default["postgresql"]["apt_key"]          = "https://www.postgresql.org/media/keys/ACCC4CF8.asc"
 
 default["postgresql"]["environment_variables"]           = {}
 default["postgresql"]["pg_ctl_options"]                  = ""


### PR DESCRIPTION
The current location is returning a 404

```
curl -I http://apt.postgresql.org/pub/repos/apt/ACCC4CF8.asc
HTTP/1.1 404 Not Found
Content-Type: text/html
Content-Length: 345
Date: Wed, 30 Apr 2014 10:02:00 GMT
Server: lighttpd/1.4.31
```

This updates the location per the [README](http://apt.postgresql.org/pub/repos/apt/README)
