### PR TITLE
add ubuntu-14.04 platform to test kitchen

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -14,6 +14,7 @@ platforms:
     attributes:
       postgresql:
         apt_distribution: precise
+  - name: ubuntu-14.04
 
 
 suites:


### PR DESCRIPTION
`kitchen verify` is green, the trap is clean. :no_entry_sign: :ghost: 
