### PR TITLE
Add `ssl_ca_file` and `ssl_crl_file` inside the config

### DIFF
--- a/templates/default/postgresql.conf.erb
+++ b/templates/default/postgresql.conf.erb
@@ -92,6 +92,8 @@ ssl = <%= node["postgresql"]["ssl"] %>        # (change requires restart)
 <% if node["postgresql"]["version"].to_f > 9.1 %>
 ssl_cert_file = '<%= node["postgresql"]["ssl_cert_file"] %>' # (change requires restart)
 ssl_key_file = '<%= node["postgresql"]["ssl_key_file"] %>'   # (change requires restart)
+ssl_ca_file = '<%= node["postgresql"]["ssl_ca_file"] %>'   # (change requires restart)
+ssl_crl_file = '<%= node["postgresql"]["ssl_crl_file"] %>'   # (change requires restart)
 <% end %>
 #password_encryption = <%= node["postgresql"]["password_encryption"] %>
 #db_user_namespace = <%= node["postgresql"]["db_user_namespace"] %>


### PR DESCRIPTION
These are mentioned in the `README` and have defaults, however, they are not being exported in the `postgresql.conf`.

Just a recommendation - would be great if there are a couple of lines explaining how to run the tests and the linters locally.