### PR TITLE
remove duplicate attribute

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -38,12 +38,6 @@ default["postgresql"]["conf_custom"]                     = false  # if true, onl
 default["postgresql"]["initdb_options"]                  = "--locale=en_US.UTF-8"
 
 #------------------------------------------------------------------------------
-# POSTGIS
-#------------------------------------------------------------------------------
-
-default["postgis"]["version"]                            = "1.5"
-
-#------------------------------------------------------------------------------
 # FILE LOCATIONS
 #------------------------------------------------------------------------------
 default["postgresql"]["data_directory"]                  = "/var/lib/postgresql/#{node["postgresql"]["version"]}/main"


### PR DESCRIPTION
Attribute `default["postgis"]["version"] ` is already specified in the `attributes/postgis.rb` file