### PR TITLE
Removed escaping from DROP ROLE due to error being thrown while dropping user.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "github@phlippers.net"
 license          "MIT"
 description      "Installs PostgreSQL, The world's most advanced open source database."
 long_description IO.read(File.join(File.dirname(__FILE__), "README.md"))
-version          "0.16.2"
+version          "0.16.3"
 
 recipe "postgresql",                   "Set up the apt repository and install dependent packages"
 recipe "postgresql::apt_repository",   "Internal recipe to setup the apt repository"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "github@phlippers.net"
 license          "MIT"
 description      "Installs PostgreSQL, The world's most advanced open source database."
 long_description IO.read(File.join(File.dirname(__FILE__), "README.md"))
-version          "0.16.1"
+version          "0.16.1.1"
 
 recipe "postgresql",                   "Set up the apt repository and install dependent packages"
 recipe "postgresql::apt_repository",   "Internal recipe to setup the apt repository"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "github@phlippers.net"
 license          "MIT"
 description      "Installs PostgreSQL, The world's most advanced open source database."
 long_description IO.read(File.join(File.dirname(__FILE__), "README.md"))
-version          "0.16.1.1"
+version          "0.16.2"
 
 recipe "postgresql",                   "Set up the apt repository and install dependent packages"
 recipe "postgresql::apt_repository",   "Internal recipe to setup the apt repository"

--- a/providers/user.rb
+++ b/providers/user.rb
@@ -41,7 +41,7 @@ action :drop do
     converge_by "Drop PostgreSQL User #{new_resource.name}" do
       execute "drop postgresql user #{new_resource.name}" do
         user "postgres"
-        command %(psql -c 'DROP ROLE IF EXISTS \\\"#{new_resource.name}\\\"')
+        command %(psql -c 'DROP ROLE IF EXISTS \\"#{new_resource.name}\\"')
         sensitive true
       end
 

--- a/providers/user.rb
+++ b/providers/user.rb
@@ -41,7 +41,7 @@ action :drop do
     converge_by "Drop PostgreSQL User #{new_resource.name}" do
       execute "drop postgresql user #{new_resource.name}" do
         user "postgres"
-        command %(psql -c 'DROP ROLE IF EXISTS \\"#{new_resource.name}\\"')
+        command %(psql -c 'DROP ROLE IF EXISTS "#{new_resource.name}"')
         sensitive true
       end
 


### PR DESCRIPTION
I encountered the following issue while trying to drop a user: 

```
================================================================================
Error executing action `run` on resource 'execute[drop postgresql user abc123]'
================================================================================

Mixlib::ShellOut::ShellCommandFailed
------------------------------------
Expected process to exit with [0], but received '1'
---- Begin output of psql -c 'DROP ROLE IF EXISTS \"abc123\"' ----
STDOUT: 
STDERR: ERROR:  syntax error at or near "\"
LINE 1: DROP ROLE IF EXISTS \"abc123\"
                            ^
---- End output of psql -c 'DROP ROLE IF EXISTS \"abc123\"' ----
Ran psql -c 'DROP ROLE IF EXISTS \"abc123\"' returned 1

```

and was able to remedy it by removing the escaping that was happening within the user.rb file.  It took a couple edits to get it right, so my version jumped by 2.  I'm also a chef n00b, so let me know if something needs to be modified.  Thanks!
