### PR TITLE
support Debian 8 (systemd)

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -9,6 +9,7 @@ provisioner:
 
 platforms:
   - name: debian-7.8
+  - name: debian-8.0
   - name: ubuntu-12.04
   - name: ubuntu-14.04
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@ AllCops:
   Exclude:
     - ".bundle/**/*"
     - "vendor/**/*"
+    - "Guardfile"
 
 LineLength:
   Max: 80

--- a/Gemfile
+++ b/Gemfile
@@ -3,17 +3,17 @@ source "https://rubygems.org"
 gem "chef", "~> #{ENV.fetch("CHEF_VERSION", "12.0.3")}"
 gem "chefspec", "~> 4.2.0"
 
-gem "berkshelf", "~> 3.2.3"
+gem "berkshelf", "~> 3.3.0"
 gem "foodcritic", "~> 4.0.0"
 gem "license_finder", "~> 1.2.0"
 gem "rake", "~> 10.4.0"
-gem "rubocop", "~> 0.29.1"
-gem "serverspec", "~> 2.8.0"
+gem "rubocop", "~> 0.32.1"
+gem "serverspec", "~> 2.19.0"
 
 group :integration do
   gem "busser-serverspec", "~> 0.5.3"
   gem "guard-rspec", "~> 4.5.0"
   gem "guard-rubocop", "~> 1.2.0"
-  gem "kitchen-vagrant", "~> 0.15.0"
-  gem "test-kitchen", "~> 1.3.1"
+  gem "kitchen-vagrant", "~> 0.18.0"
+  gem "test-kitchen", "~> 1.4.1"
 end

--- a/recipes/debian_backports.rb
+++ b/recipes/debian_backports.rb
@@ -4,10 +4,11 @@
 #
 
 # backports for initial support
-backports_uri = if node["lsb"]["codename"] == "wheezy"
-                  "http://cdn.debian.net/debian"
-                else
+backports_uri = if node["lsb"]["codename"] == "squeeze"
                   "http://backports.debian.org/debian-backports"
+                else
+                  # starting with 7.0/wheezy:
+                  "http://httpredir.debian.org/debian"
                 end
 
 apt_repository "debian-backports" do

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -12,3 +12,20 @@ service "postgresql" do
   supports reload: true, restart: true, status: true
   action Array(node["postgresql"]["service_actions"]).map(&:to_sym)
 end
+
+# Debian 8 and above:
+#
+# PGDG's systemd-enabled packages require a service per version/cluster
+# see:
+# http://bazaar.launchpad.net/~ubuntu-branches/debian/jessie/postgresql-common/jessie/view/head:/systemd/README.systemd
+#
+if node["platform"] == "debian" && node["platform_version"].to_f >= 8.0
+  # cluster_name typically defaults to 'main'
+  main_cluster_name = File.basename node["postgresql"]["data_directory"]
+
+  # service name will be e.g. 'postgresql@9.4-main'
+  service "postgresql@#{node["postgresql"]["version"]}-#{main_cluster_name}" do
+    supports reload: true, restart: true, status: true
+    action Array(node["postgresql"]["service_actions"]).map(&:to_sym)
+  end
+end

--- a/spec/data_directory_spec.rb
+++ b/spec/data_directory_spec.rb
@@ -22,7 +22,7 @@ describe "postgresql::data_directory" do
 
   context "the data directory already exists" do
     before do
-      allow(::File).to receive_messages(:exist? => true)
+      allow(::File).to receive_messages(exist?: true)
     end
 
     specify do


### PR DESCRIPTION
Hi,

i've added basic support for Debian 8.0, however there are open issues:
- minitest-handler seems to be broken with chef 12 and nobody seems to be interested to care anymore. audit-mode seems to be the future… Remove minitests?
- Debian 8 comes with systemd. When using the appropropriate pgdg packages, pg does not start the main cluster by default and other calls, e.g. to change users/password fail. Still investigating.
