### PR TITLE
Faraday fails when running rspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 gem "chef", "~> #{ENV.fetch("CHEF_VERSION", "12.0.3")}"
 gem "chefspec", "~> 4.2.0"
 
-gem "berkshelf", "~> 3.2.3"
+gem "berkshelf", "~> 4.0.1"
 gem "foodcritic", "~> 4.0.0"
 gem "license_finder", "~> 1.2.0"
 gem "rake", "~> 10.4.0"


### PR DESCRIPTION
The error is:

```
:gzip is not registered on Faraday::Response (Faraday::Error)
```

Upgrading to berkshelf >= 4.x solves this problem.

See also here: https://github.com/berkshelf/berkshelf/issues/1466
