### PR TITLE
Handle potentially missing attributes for (currently) un-supported platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ default["postgresql"]["cfg_update_action"]               = :restart
 #----------------------------------------------------------------------------
 # APT REPOSITORY
 #----------------------------------------------------------------------------
-default["postgresql"]["apt_distribution"]                = node["lsb"]["codename"]
+default["postgresql"]["apt_distribution"]                = node["lsb"] && node["lsb"]["codename"]
 default["postgresql"]["apt_repository"]                  = "apt.postgresql.org"
 default["postgresql"]["apt_uri"]                         = "http://apt.postgresql.org/pub/repos/apt"
 default["postgresql"]["apt_components"]                  = ["main"]

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,7 +20,7 @@ default["postgresql"]["cfg_update_action"]               = :restart
 # APT REPOSITORY
 #------------------------------------------------------------------------------
 
-default["postgresql"]["apt_distribution"] = node["lsb"]["codename"]
+default["postgresql"]["apt_distribution"] = node["lsb"] && node["lsb"]["codename"]
 default["postgresql"]["apt_repository"]   = "apt.postgresql.org"
 default["postgresql"]["apt_uri"]          = "http://apt.postgresql.org/pub/repos/apt"
 default["postgresql"]["apt_components"]   = ["main", node["postgresql"]["version"]]

--- a/recipes/debian_backports.rb
+++ b/recipes/debian_backports.rb
@@ -4,7 +4,7 @@
 #
 
 # backports for initial support
-backports_uri = if node["lsb"]["codename"] == "wheezy"
+backports_uri = if node["lsb"] && node["lsb"]["codename"] == "wheezy"
                   "http://cdn.debian.net/debian"
                 else
                   "http://backports.debian.org/debian-backports"
@@ -12,13 +12,13 @@ backports_uri = if node["lsb"]["codename"] == "wheezy"
 
 apt_repository "debian-backports" do
   uri backports_uri
-  distribution "#{node["lsb"]["codename"]}-backports"
+  distribution "#{node["lsb"] && node["lsb"]["codename"]}-backports"
   components ["main"]
 end
 
 # backports support for debian
 %w[libpq5 postgresql-common].each do |pkg|
   package pkg do
-    options "-t #{node["lsb"]["codename"]}-backports"
+    options "-t #{node["lsb"] && node["lsb"]["codename"]}-backports"
   end
 end


### PR DESCRIPTION
I'm using this cookbook with an application cookbook that I've been using with computers running Ubuntu. But I'm working on another wrapper cookbook for setting-up development instances of my application and I'd like to support Mac OS and Windows as well as Linux (Ubuntu). I'm interested in working on adding Mac OS and Windows support to this cookbook but in the meantime I'd like to be able to implement 'hard-coded' support for those platforms and use this cookbook for Linux. Unfortunately, this cookbook can't be compiled by Chef on non-Linux platforms because of unguarded attribute access for attributes that only exist for Linux nodes. These changes should fix the compilation errors on currently un-supported platforms; they do on a Mac OS X computer I have.
