### PR TITLE
Increased version > 1

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -2,7 +2,7 @@ name             "postgresql"
 maintainer       "Phil Cohen"
 maintainer_email "github@phlippers.net"
 license          "MIT"
-description      "Installs PostgreSQL, The world's most advanced open source database. NOTE this is my own fork. All it does is increase the version to greater than 1 so that if you have other recipes that use 'Database' they do not complain."
+description      "Installs PostgreSQL, The world's most advanced open source database."
 long_description IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version          "1.16.1"
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -2,9 +2,9 @@ name             "postgresql"
 maintainer       "Phil Cohen"
 maintainer_email "github@phlippers.net"
 license          "MIT"
-description      "Installs PostgreSQL, The world's most advanced open source database."
+description      "Installs PostgreSQL, The world's most advanced open source database. NOTE this is my own fork. All it does is increase the version to greater than 1 so that if you have other recipes that use 'Database' they do not complain."
 long_description IO.read(File.join(File.dirname(__FILE__), "README.md"))
-version          "0.16.1"
+version          "1.16.1"
 
 recipe "postgresql",                   "Set up the apt repository and install dependent packages"
 recipe "postgresql::apt_repository",   "Internal recipe to setup the apt repository"


### PR DESCRIPTION
If you have another recipe that uses the "database" cookbook, you will get conflicts because that cookbook requires a postgresql version greater than 1. I simply changed 0.16 to 1.16
