### PR TITLE
Removed references to the "checkpoint_segments" setting

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -135,7 +135,6 @@ default["postgresql"]["commit_delay"]                    = 0
 default["postgresql"]["commit_siblings"]                 = 5
 
 # checkpoints
-default["postgresql"]["checkpoint_segments"]             = 3
 default["postgresql"]["checkpoint_timeout"]              = "5min"
 default["postgresql"]["checkpoint_completion_target"]    = 0.5
 default["postgresql"]["checkpoint_warning"]              = "30s"

--- a/templates/default/postgresql.conf.erb
+++ b/templates/default/postgresql.conf.erb
@@ -209,9 +209,6 @@ commit_delay = <%= node["postgresql"]["commit_delay"] %>     # range 0-100000, i
 
 # - Checkpoints -
 
-<%- if node["postgresql"]["checkpoint_segments"] %>
-checkpoint_segments = <%= node["postgresql"]["checkpoint_segments"] %>    # in logfile segments, min 1, 16MB each
-<%- end %>
 <%- if node["postgresql"]["checkpoint_timeout"] %>
 checkpoint_timeout = <%= node["postgresql"]["checkpoint_timeout"] %>    # range 30s-1h
 <%- end %>


### PR DESCRIPTION
This was removed from the eba_node default.rb, but it was hanging around in the postgres cookbook.